### PR TITLE
plymouthd.defaults: Change default to endlessos-static

### DIFF
--- a/src/plymouthd.defaults
+++ b/src/plymouthd.defaults
@@ -1,5 +1,5 @@
 # Distribution defaults. Changes to this file will get overwritten during
 # upgrades.
 [Daemon]
-Theme=endlessos
+Theme=endlessos-static
 ShowDelay=0


### PR DESCRIPTION
endlessm/eos-shell#3769
