### PR TITLE
Trigger update-initramfs

### DIFF
--- a/debian/plymouth.triggers
+++ b/debian/plymouth.triggers
@@ -1,0 +1,1 @@
+activate update-initramfs


### PR DESCRIPTION
We're no longer shipping the update-initramfs executable, so make
this package activate the update-initramfs trigger.

Since dracut declares its "interest" in this trigger, dracut's postinst
will be run when updating/installing plymouth.

https://phabricator.endlessm.com/T4899
https://phabricator.endlessm.com/T11096