### PR TITLE
T11575: Increase device timeout to 30 seconds

### DIFF
--- a/src/plymouthd.defaults
+++ b/src/plymouthd.defaults
@@ -3,4 +3,4 @@
 [Daemon]
 Theme=endlessos-squiggly
 ShowDelay=0
-DeviceTimeout=5
+DeviceTimeout=30


### PR DESCRIPTION
The DRM device may take quite a long time to become available on some
machines (namely the Asus X555DG). Lets increase the device timeout so
we have a better chance of having them booting with a graphical splash.

https://phabricator.endlessm.com/T11575