### PR TITLE
Disable HiDPI

### DIFF
--- a/src/libply/ply-utils.c
+++ b/src/libply/ply-utils.c
@@ -953,6 +953,8 @@ ply_get_device_scale (uint32_t width,
         double dpi_x, dpi_y;
         const char *force_device_scale;
 
+        return 1;
+
         device_scale = 1;
 
         if ((force_device_scale = getenv ("PLYMOUTH_FORCE_SCALE")))


### PR DESCRIPTION
Scaling our boot splash makes it pretty slow, so lets disable HiDPI
support for now.

https://phabricator.endlessm.com/T11009