### PR TITLE
Remove version of init-system-helpers dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Depends:
  ${misc:Depends},
  ${shlibs:Depends},
  initramfs-tools | dracut,
- init-system-helpers (>= 1.18),
+ init-system-helpers,
 Conflicts: console-common
 Breaks: plymouth-drm (<< 0.9.0-6~), plymouth-themes (<< 0.9.0-8~)
 Replaces: plymouth-drm (<< 0.9.0-6~), plymouth-themes (<< 0.9.0-8~)

--- a/debian/plymouth.postinst
+++ b/debian/plymouth.postinst
@@ -10,7 +10,8 @@ case "${1}" in
 		# The option has been removed but we still need to take care of
 		# removing the leftover.
 		if dpkg --compare-versions "$2" le-nl "0.9.0-6~"; then
-			deb-systemd-helper purge plymouth-halt.service plymouth-kexec.service plymouth-poweroff.service plymouth-quit.service plymouth-quit-wait.service plymouth-read-write.service plymouth-reboot.service plymouth-start.service >/dev/null
+			export _DEB_SYSTEMD_HELPER_PURGE=1
+			deb-systemd-helper disable plymouth-halt.service plymouth-kexec.service plymouth-poweroff.service plymouth-quit.service plymouth-quit-wait.service plymouth-read-write.service plymouth-reboot.service plymouth-start.service >/dev/null
 			deb-systemd-helper unmask plymouth-halt.service plymouth-kexec.service plymouth-poweroff.service plymouth-quit.service plymouth-quit-wait.service plymouth-read-write.service plymouth-reboot.service plymouth-start.service >/dev/null
 		fi
 		if [ -x /usr/sbin/update-initramfs ]


### PR DESCRIPTION
Debian depends on >=1.18 because this is the version that introduces
"deb-systemd-helper purge". Previously the same functionality was
available by calling "deb-systemd-helper disable" with
_DEB_SYSTEMD_HELPER_PURGE=1 set in the environment.

Since eos2.6 still ships init-system-helpers 1.15 lets use the older
interface and remove the version dependency.

https://phabricator.endlessm.com/T11575