### PR TITLE
device-manager: probe existing DRM devices at startup

### DIFF
--- a/src/libply-splash-core/ply-device-manager.c
+++ b/src/libply-splash-core/ply-device-manager.c
@@ -816,6 +816,7 @@ ply_device_manager_watch_devices (ply_device_manager_t                *manager,
         }
 
         watch_for_udev_events (manager);
+        create_devices_for_subsystem (manager, SUBSYSTEM_DRM);
         ply_event_loop_watch_for_timeout (manager->loop,
                                          device_timeout,
                                          (ply_event_loop_timeout_handler_t)


### PR DESCRIPTION
A regression introduced in 7e37d58be3e9acff36c53c420b399c18d08bd8f8
means that we only look for DRM devices that appear while we're waiting,
we don't consider any that are already present before we started.

shutdown splash was not appearing because of this.

Solve this by explicitly searching for already-initialized DRM devices as
we start up.

https://bugs.freedesktop.org/show_bug.cgi?id=96560
https://phabricator.endlessm.com/T12059