### PR TITLE
ply-device-manager: drop HAVE_UDEV checks

### DIFF
--- a/src/libply-splash-core/ply-device-manager.c
+++ b/src/libply-splash-core/ply-device-manager.c
@@ -974,9 +974,7 @@ ply_device_manager_pause (ply_device_manager_t *manager)
 {
         ply_trace ("ply_device_manager_pause() called, stopping watching for udev events");
         manager->paused = true;
-#ifdef HAVE_UDEV
         stop_watching_for_udev_events (manager);
-#endif
 }
 
 void
@@ -984,11 +982,9 @@ ply_device_manager_unpause (ply_device_manager_t *manager)
 {
         ply_trace ("ply_device_manager_unpause() called, resuming watching for udev events");
         manager->paused = false;
-#ifdef HAVE_UDEV
         if (manager->device_timeout_elapsed) {
                 ply_trace ("ply_device_manager_unpause(): timeout elapsed while paused, looking for udev devices");
                 create_devices_from_udev (manager);
         }
         watch_for_udev_events (manager);
-#endif
 }


### PR DESCRIPTION
Commit cc2ab9c7fee0a558a (device-manager: don't watch for udev events
when deactivated) was backported from master with some HAVE_UDEV
checks present.

However that flag is new on master, does not exist on this old version.
Remove those ifdefs.

https://phabricator.endlessm.com/T24913